### PR TITLE
Add AppArmor profile

### DIFF
--- a/etc/apparmor.d/bootclockrandomization
+++ b/etc/apparmor.d/bootclockrandomization
@@ -1,3 +1,6 @@
+## Copyright (C) 2012 - 2018 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
 #include <tunables/global>
 
 profile bootclockrandomization /usr/share/bootclockrandomization/* {

--- a/etc/apparmor.d/bootclockrandomization
+++ b/etc/apparmor.d/bootclockrandomization
@@ -3,7 +3,7 @@
 
 #include <tunables/global>
 
-profile bootclockrandomization /usr/share/bootclockrandomization/* {
+profile bootclockrandomization /usr/share/bootclockrandomization/* flags=(attach_disconnected) {
   #include <abstractions/base>
   #include <abstractions/bash>
 

--- a/etc/apparmor.d/bootclockrandomization
+++ b/etc/apparmor.d/bootclockrandomization
@@ -1,0 +1,25 @@
+#include <tunables/global>
+
+profile bootclockrandomization /usr/share/bootclockrandomization/* {
+  #include <abstractions/base>
+  #include <abstractions/bash>
+
+  capability sys_time,
+
+  /bin/bash ix,
+  /bin/date mrix,
+  /bin/rm mrix,
+  /bin/touch mrix,
+  /usr/bin/id mrix,
+  /usr/bin/od mrix,
+  /usr/bin/shuf mrix,
+
+  owner /etc/nsswitch.conf r,
+  owner /etc/passwd r,
+
+  owner /run/bootclockrandomization/{fail,success} w,
+  owner /usr/share/bootclockrandomization/* r,
+  owner /var/log/bootclockrandomization.log w,
+  
+  #include <local/bootclockrandomization>
+}


### PR DESCRIPTION
The main reason for this is so I can remove the sys_time capability from the [full system AppArmor policy](https://forums.whonix.org/t/apparmor-for-complete-system-including-init-pid1-systemd-everything-full-system-mac-policy/8339/) (once /usr/bin/sdwdate is also confined) which would get rid of a lot of potential attack surface.